### PR TITLE
NYUP 739 - Submodule Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-src/solr/open-square-metadata
+# src/solr/open-square-metadata

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "src/solr/open-square-metadata"]
-    url = https://github.com/nyudlts/solr_conf_open-square-metadata.git
-    path = src/solr/open-square-metadata
-    branch = stagediscovery.dlib.nyu.edu
 [submodule "open-square-metadata"]
 	path = src/solr/open-square-metadata
 	url = git@github.com:nyudlts/solr_conf_open-square-metadata.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
     url = https://github.com/nyudlts/solr_conf_open-square-metadata.git
     path = src/solr/open-square-metadata
     branch = stagediscovery.dlib.nyu.edu
+[submodule "open-square-metadata"]
+	path = src/solr/open-square-metadata
+	url = git@github.com:nyudlts/solr_conf_open-square-metadata.git
+	branch = stagediscovery.dlib.nyu.edu


### PR DESCRIPTION
Ready for review

This PR will add the following:
- ssh protocol for submodule link
- fix to .gitignore

In order to test this PR:
- update branch 
  - `git pull`
- update submodules in this repo 
  - `git submodules update --init`
  - verify `open-square-metadata` has been cloned
- clone data repository not used as submodule into `src` directory 
  - `cd src`
  - `git clone git@github.com:NYULibraries/dlts-epub-metadata.git`
- load schema and start solr 
  - `docker compose up -d`
- load data into local solr instance using Deno
  - `deno run --allow-read --allow-net index.ts`
